### PR TITLE
Fix resource names passed to create_resources()

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -9,6 +9,6 @@ class easyrsa::config() inherits easyrsa {
   create_resources('easyrsa::pki', $easyrsa::pkis)
   create_resources('easyrsa::ca', $easyrsa::cas)
   create_resources('easyrsa::dh', $easyrsa::dhparms)
-  create_resources('easyrsa::servers', $easyrsa::servers)
-  create_resources('easyrsa::clients', $easyrsa::clients)
+  create_resources('easyrsa::server', $easyrsa::servers)
+  create_resources('easyrsa::client', $easyrsa::clients)
 }


### PR DESCRIPTION
Signed-off-by: Simon Deziel <simon@sdeziel.info>